### PR TITLE
Component Support

### DIFF
--- a/test/fixtures/component-attributes/actual.js
+++ b/test/fixtures/component-attributes/actual.js
@@ -1,0 +1,3 @@
+return <Comp class="myClass" id={id} {...props} key="test" data-expanded={expanded} {...props.attrs}></Comp>;
+
+

--- a/test/fixtures/component-attributes/expected.js
+++ b/test/fixtures/component-attributes/expected.js
@@ -1,0 +1,20 @@
+function _attr(value, name) {
+  attr(name, value);
+}
+
+function _forOwn(object, iterator) {
+  for (var prop in object) if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+}
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+elementOpenStart(Comp, "test", ["class", "myClass", "key", "test"]);
+attr("id", id);
+
+_forOwn(props, _attr);
+
+attr("data-expanded", expanded);
+
+_forOwn(props.attrs, _attr);
+
+elementOpenEnd(Comp);
+return elementClose(Comp);

--- a/test/fixtures/component/actual.js
+++ b/test/fixtures/component/actual.js
@@ -1,0 +1,1 @@
+return <Comp></Comp>;

--- a/test/fixtures/component/expected.js
+++ b/test/fixtures/component/expected.js
@@ -1,0 +1,2 @@
+elementOpen(Comp);
+return elementClose(Comp);


### PR DESCRIPTION
An initial Component support, which intentionally punts on what to do with attributes. With the way iDOM is currently handling notifications ("create" and "delete"), it'd be very hard to pull attributes into a hash to push into the notification function. Instead, retrieve them with `getAttribute` / `this[prop]` on the component's root element.

Closes #9.

TODO
--------
- [ ] We still need a way to translate from some arbitrary `Component` class into the proper `tagName`.
- [ ] What are we going to do with children elements?