### PR TITLE
Allow a common runtime

### DIFF
--- a/test/fixtures/runtime/actual.js
+++ b/test/fixtures/runtime/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  var div = <div id="test" {...props}><div/></div>;
+
+  return <root>{div}</root>;
+}

--- a/test/fixtures/runtime/expected.js
+++ b/test/fixtures/runtime/expected.js
@@ -1,0 +1,13 @@
+function render() {
+  var div = iDOM.jsxWrapper(function (_props) {
+    elementOpenStart("div", null, ["id", "test"]);
+    iDOM.forOwn(_props, iDOM.attr);
+    elementOpenEnd("div");
+    elementVoid("div");
+    return elementClose("div");
+  }, [props]);
+
+  elementOpen("root");
+  iDOM.renderArbitrary(div);
+  return elementClose("root");
+}

--- a/test/fixtures/runtime/options.json
+++ b/test/fixtures/runtime/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "runtime": "iDOM"
+  }
+}


### PR DESCRIPTION
Instead of injecting our helpers in multiple files, allow devs to import their own runtime module.

To diff, [compare](https://github.com/babel-plugins/babel-plugin-incremental-dom/compare/babel-6...runtime) it to the `babel-6` branch.