### PR TITLE
Adds option that allows passing component tags as reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,38 @@ plugin:
 }
 ```
 
+#### Component as reference
+
+You may enable the experimental `componentAsReference` option so that JSX tags
+that start with an upper case letter are passed as a reference to incremental
+DOM calls, instead of as a string. This can be useful when your code implements
+components through these kind of calls, though that's not done by incremental
+DOM automatically. Note that this will break unless you have code to handle it.
+
+
+```js
+// Before
+<MyComponent />;
+```
+
+```js
+// After
+elementVoid(MyComponent);
+```
+
+To do this, simply add the `componentAsReference` option to the Incremental DOM
+plugin:
+
+```json
+{
+  "plugins": [[
+    "incremental-dom", {
+      "componentAsReference": true
+    }
+  ]],
+}
+```
+
 #### Runtime
 
 By deafult, `babel-plugin-incremental-dom` injects several helpers into

--- a/README.md
+++ b/README.md
@@ -192,13 +192,13 @@ plugin:
 }
 ```
 
-#### Component as reference
+#### Components
 
-You may enable the experimental `componentAsReference` option so that JSX tags
-that start with an upper case letter are passed as a reference to incremental
-DOM calls, instead of as a string. This can be useful when your code implements
-components through these kind of calls, though that's not done by incremental
-DOM automatically. Note that this will break unless you have code to handle it.
+You may enable the experimental `components` option so that JSX tags that start
+with an upper case letter are passed as a reference to incremental DOM calls,
+instead of as a string. This can be useful when your code implements components
+through these kind of calls, though that's not done by incremental DOM
+automatically. Note that this will break unless you have code to handle it.
 
 
 ```js
@@ -211,14 +211,14 @@ DOM automatically. Note that this will break unless you have code to handle it.
 elementVoid(MyComponent);
 ```
 
-To do this, simply add the `componentAsReference` option to the Incremental DOM
+To do this, simply add the `components` option to the Incremental DOM
 plugin:
 
 ```json
 {
   "plugins": [[
     "incremental-dom", {
-      "componentAsReference": true
+      "components": true
     }
   ]],
 }

--- a/src/helpers/element-close-call.js
+++ b/src/helpers/element-close-call.js
@@ -2,6 +2,7 @@ import toFunctionCall from "./ast/to-function-call";
 import toReference from "./ast/to-reference";
 
 import iDOMMethod from "./idom-method";
+import isComponent from "./is-component";
 
 // Returns the closing element's function call.
 export default function elementCloseCall(t, path, plugin, { components }) {
@@ -18,6 +19,6 @@ export default function elementCloseCall(t, path, plugin, { components }) {
     }
   }
 
-  const isComponent = /^[A-Z]/.test(node.name.name);
-  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, isComponent && components)]);
+  const useReference = isComponent(node.name.name) && components;
+  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, useReference)]);
 }

--- a/src/helpers/element-close-call.js
+++ b/src/helpers/element-close-call.js
@@ -18,5 +18,6 @@ export default function elementCloseCall(t, path, plugin, { componentAsReference
     }
   }
 
-  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, componentAsReference)]);
+  const isComponent = /^[A-Z]/.test(node.name.name);
+  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, isComponent && componentAsReference)]);
 }

--- a/src/helpers/element-close-call.js
+++ b/src/helpers/element-close-call.js
@@ -4,7 +4,7 @@ import toReference from "./ast/to-reference";
 import iDOMMethod from "./idom-method";
 
 // Returns the closing element's function call.
-export default function elementCloseCall(t, path, plugin) {
+export default function elementCloseCall(t, path, plugin, { componentAsReference }) {
   const node = path.node;
 
   // Self closing elements may not need a closing element.
@@ -18,5 +18,5 @@ export default function elementCloseCall(t, path, plugin) {
     }
   }
 
-  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name)]);
+  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, componentAsReference)]);
 }

--- a/src/helpers/element-close-call.js
+++ b/src/helpers/element-close-call.js
@@ -4,7 +4,7 @@ import toReference from "./ast/to-reference";
 import iDOMMethod from "./idom-method";
 
 // Returns the closing element's function call.
-export default function elementCloseCall(t, path, plugin, { componentAsReference }) {
+export default function elementCloseCall(t, path, plugin, { components }) {
   const node = path.node;
 
   // Self closing elements may not need a closing element.
@@ -19,5 +19,5 @@ export default function elementCloseCall(t, path, plugin, { componentAsReference
   }
 
   const isComponent = /^[A-Z]/.test(node.name.name);
-  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, isComponent && componentAsReference)]);
+  return toFunctionCall(t, iDOMMethod("elementClose", plugin), [toReference(t, node.name, isComponent && components)]);
 }

--- a/src/helpers/element-open-call.js
+++ b/src/helpers/element-open-call.js
@@ -6,7 +6,8 @@ import extractOpenArguments from "./extract-open-arguments";
 
 // Returns the opening element's function call.
 export default function elementOpenCall(t, path, plugin, options) {
-  const tag = toReference(t, path.node.name, options.componentAsReference);
+  const isComponent = /^[A-Z]/.test(path.node.name.name);
+  const tag = toReference(t, path.node.name, isComponent && options.componentAsReference);
   const args = [tag];
   const {
     key,

--- a/src/helpers/element-open-call.js
+++ b/src/helpers/element-open-call.js
@@ -7,7 +7,7 @@ import extractOpenArguments from "./extract-open-arguments";
 // Returns the opening element's function call.
 export default function elementOpenCall(t, path, plugin, options) {
   const isComponent = /^[A-Z]/.test(path.node.name.name);
-  const tag = toReference(t, path.node.name, isComponent && options.componentAsReference);
+  const tag = toReference(t, path.node.name, isComponent && options.components);
   const args = [tag];
   const {
     key,

--- a/src/helpers/element-open-call.js
+++ b/src/helpers/element-open-call.js
@@ -2,12 +2,13 @@ import toFunctionCall from "./ast/to-function-call";
 import toReference from "./ast/to-reference";
 
 import iDOMMethod from "./idom-method";
+import isComponent from "./is-component";
 import extractOpenArguments from "./extract-open-arguments";
 
 // Returns the opening element's function call.
 export default function elementOpenCall(t, path, plugin, options) {
-  const isComponent = /^[A-Z]/.test(path.node.name.name);
-  const tag = toReference(t, path.node.name, isComponent && options.components);
+  const useReference = isComponent(path.node.name.name) && options.components;
+  const tag = toReference(t, path.node.name, useReference);
   const args = [tag];
   const {
     key,

--- a/src/helpers/element-open-call.js
+++ b/src/helpers/element-open-call.js
@@ -6,7 +6,7 @@ import extractOpenArguments from "./extract-open-arguments";
 
 // Returns the opening element's function call.
 export default function elementOpenCall(t, path, plugin, options) {
-  const tag = toReference(t, path.node.name);
+  const tag = toReference(t, path.node.name, options.componentAsReference);
   const args = [tag];
   const {
     key,

--- a/src/helpers/is-component.js
+++ b/src/helpers/is-component.js
@@ -1,0 +1,5 @@
+// Detects if the given tag represents a component (that is, if it starts with a
+// capital letter).
+export default function isComponent(tag) {
+  return /^[A-Z]/.test(tag);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -67,13 +67,14 @@ export default function ({ types: t, traverse: _traverse }) {
         const isChild = isChildElement(path);
         const needsWrapper = root !== path && !isChild;
         const eager = secondaryTree || needsWrapper;
+        const componentAsReference = this.opts.componentAsReference;
 
         const { parentPath } = path;
         const explicitReturn = parentPath.isReturnStatement();
         const implicitReturn = parentPath.isArrowFunctionExpression();
 
-        const openingElement = elementOpenCall(t, path.get("openingElement"), this, { eager, hoist });
-        const closingElement = elementCloseCall(t, path.get("openingElement"), this);
+        const openingElement = elementOpenCall(t, path.get("openingElement"), this, { eager, hoist, componentAsReference });
+        const closingElement = elementCloseCall(t, path.get("openingElement"), this, { componentAsReference });
         const children = buildChildren(t, path.get("children"), this);
 
         let elements = [ openingElement, ...children ];

--- a/src/index.js
+++ b/src/index.js
@@ -67,14 +67,14 @@ export default function ({ types: t, traverse: _traverse }) {
         const isChild = isChildElement(path);
         const needsWrapper = root !== path && !isChild;
         const eager = secondaryTree || needsWrapper;
-        const componentAsReference = this.opts.componentAsReference;
+        const components = this.opts.components;
 
         const { parentPath } = path;
         const explicitReturn = parentPath.isReturnStatement();
         const implicitReturn = parentPath.isArrowFunctionExpression();
 
-        const openingElement = elementOpenCall(t, path.get("openingElement"), this, { eager, hoist, componentAsReference });
-        const closingElement = elementCloseCall(t, path.get("openingElement"), this, { componentAsReference });
+        const openingElement = elementOpenCall(t, path.get("openingElement"), this, { eager, hoist, components });
+        const closingElement = elementCloseCall(t, path.get("openingElement"), this, { components });
         const children = buildChildren(t, path.get("children"), this);
 
         let elements = [ openingElement, ...children ];

--- a/test/fixtures/element/component-as-reference/actual.js
+++ b/test/fixtures/element/component-as-reference/actual.js
@@ -1,0 +1,3 @@
+function render() {
+  return <MyComponent></MyComponent>;
+}

--- a/test/fixtures/element/component-as-reference/expected.js
+++ b/test/fixtures/element/component-as-reference/expected.js
@@ -1,0 +1,4 @@
+function render() {
+  elementOpen(MyComponent);
+  return elementClose(MyComponent);
+}

--- a/test/fixtures/element/component-as-reference/options.json
+++ b/test/fixtures/element/component-as-reference/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "componentAsReference": true
+  }
+}

--- a/test/fixtures/element/component-as-reference/options.json
+++ b/test/fixtures/element/component-as-reference/options.json
@@ -1,5 +1,5 @@
 {
   "options": {
-    "componentAsReference": true
+    "components": true
   }
 }

--- a/test/fixtures/element/component-as-string/actual.js
+++ b/test/fixtures/element/component-as-string/actual.js
@@ -1,0 +1,3 @@
+function render() {
+  return <MyComponent></MyComponent>;
+}

--- a/test/fixtures/element/component-as-string/expected.js
+++ b/test/fixtures/element/component-as-string/expected.js
@@ -1,0 +1,4 @@
+function render() {
+  elementOpen("MyComponent");
+  return elementClose("MyComponent");
+}

--- a/test/fixtures/element/member-expression-tag-component/actual.js
+++ b/test/fixtures/element/member-expression-tag-component/actual.js
@@ -1,0 +1,3 @@
+function render() {
+  return <a.b.MyComponent></a.b.MyComponent>;
+}

--- a/test/fixtures/element/member-expression-tag-component/expected.js
+++ b/test/fixtures/element/member-expression-tag-component/expected.js
@@ -1,0 +1,4 @@
+function render() {
+  elementOpen(a.b.MyComponent);
+  return elementClose(a.b.MyComponent);
+}

--- a/test/fixtures/element/member-expression-tag-component/options.json
+++ b/test/fixtures/element/member-expression-tag-component/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "components": true
+  }
+}

--- a/test/fixtures/element/non-component-as-string/actual.js
+++ b/test/fixtures/element/non-component-as-string/actual.js
@@ -1,0 +1,3 @@
+function render() {
+  return <div></div>;
+}

--- a/test/fixtures/element/non-component-as-string/expected.js
+++ b/test/fixtures/element/non-component-as-string/expected.js
@@ -1,0 +1,4 @@
+function render() {
+  elementOpen("div");
+  return elementClose("div");
+}

--- a/test/fixtures/element/non-component-as-string/options.json
+++ b/test/fixtures/element/non-component-as-string/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "componentAsReference": true
+  }
+}

--- a/test/fixtures/element/non-component-as-string/options.json
+++ b/test/fixtures/element/non-component-as-string/options.json
@@ -1,5 +1,5 @@
 {
   "options": {
-    "componentAsReference": true
+    "components": true
   }
 }


### PR DESCRIPTION
I'm not sure if this is something that you'd want to merge, but I added an option on my fork of babel-incremental-dom to enable passing upper case tags by reference to incremental dom calls, even though that doesn't work without extra code. I need this for a project I'm working on, where we already handle this case internally, but needed the compiler to work as expected.

I saw that you already have an issue (https://github.com/jridgewell/babel-plugin-incremental-dom/issues/9) for working on this feature, but since it seems to waiting for some changes on incremental dom's side I think this option I've added could be useful for some people, so sending it in case you agree as well :)