### PR TITLE
Fast path

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,63 @@ plugin:
 }
 ```
 
+#### Fast Root
+
+You may enable the experimental `fastRoot` option so that JSX tags
+inside the root element are never wrapped inside a closure. For code
+with array maps, this should significantly decrease memory usage and
+increase speed.
+
+
+```js
+// Disabled (default)
+function render() {
+  elementOpen("ul");
+
+  _renderArbitrary(items.map(function (item) {
+    return _jsxWrapper(function (_item$name) {
+      elementOpen("li");
+
+      _renderArbitrary(_item$name);
+
+      return elementClose("li");
+    }, [item.name]);
+  }));
+
+  return elementClose("ul");
+}
+```
+
+```js
+// Enabled
+function render() {
+  elementOpen("ul");
+
+  items.map(function (item) {
+    elementOpen("li");
+
+    _renderArbitrary(item.name);
+
+    return elementClose("li");
+  });
+
+  return elementClose("ul");
+}
+```
+
+To do this, simply add the `fastRoot` option to the Incremental DOM
+plugin:
+
+```json
+{
+  "plugins": [[
+    "incremental-dom", {
+      "fastRoot": true
+    }
+  ]],
+}
+```
+
 #### Components
 
 You may enable the experimental `components` option so that JSX tags

--- a/src/helpers/ast/to-reference.js
+++ b/src/helpers/ast/to-reference.js
@@ -1,18 +1,12 @@
 import * as t from "babel-types";
 
-const memberExpressionSplitter = /\./g;
-
 // Helper to transform a JSX identifier into a normal reference.
 export default function toReference(node, identifier = false) {
   if (typeof node === "string") {
-    if (memberExpressionSplitter.test(node)) {
-      return node.
-        split(memberExpressionSplitter).
-        map((s) => t.identifier(s)).
-        reduce((obj, prop) => t.memberExpression(obj, prop));
-    }
-
-    return t.identifier(node);
+    return node.
+      split(".").
+      map((s) => t.identifier(s)).
+      reduce((obj, prop) => t.memberExpression(obj, prop));
   }
 
   if (t.isJSXIdentifier(node)) {

--- a/src/helpers/is-child-element.js
+++ b/src/helpers/is-child-element.js
@@ -5,47 +5,61 @@ import isRootJSX from "./is-root-jsx";
 function descendant(path) {
   let isChild = false;
 
+  const direct = directChild(path);
+  if (direct) {
+    return direct;
+  }
+
   path.findParent((path) => {
     if (path.isJSXAttribute()) {
       // Stop traversing, we are not a child.
       return true;
     }
+
     if (path.isJSXElement()) {
-      if (directChild(path)) {
-        return false;
+      if (!directChild(path)) {
+        // This element is the top of a tree of JSX elements
+        // If it's the root tree, we are a child.
+        isChild = isRootJSX(path);
+        return true;
       }
-      // This element is the top of a tree of JSX elements
-      // If it's the root tree, we are a child.
-      isChild = isRootJSX(path);
-      return true;
     }
   });
 
-  return isChild;
+  if (!isChild) {
+    return null;
+  }
+
+  return path.findParent((path) => {
+    return !path.parentPath || path.parentPath.isJSX();
+  });
 }
 
 // It is only a child if it's immediate parent is a JSX element,
 // or it is an ExpressionContainer who's parent is.
 function directChild(path) {
   let isChild = false;
+  let child = path;
 
   path.findParent((path) => {
     if (path.isJSXElement()) {
       isChild = true;
       return true;
     }
+
     if (path.isJSXExpressionContainer()) {
       // Defer to what the parent is.
       return false;
     }
+
+    child = path;
     return true;
   });
 
-  return isChild;
+  return isChild ? child : null;
 }
 
 // Detects if this element is not a child of another JSX element
-export default function isChildElement(path, { opts }) {
-  return directChild(path) || (opts.fastRoot && descendant(path));
+export default function childAncestor(path, { opts }) {
+  return (opts.fastRoot ? descendant : directChild)(path);
 }
-

--- a/src/helpers/is-child-element.js
+++ b/src/helpers/is-child-element.js
@@ -1,17 +1,51 @@
-// Detects if this element is not a child of another JSX element
-export default function isChildElement(path) {
+import isRootJSX from "./is-root-jsx";
+
+// It is only a child if it is a descendant of a JSX element but not a
+// JSX Attribute.
+function descendant(path) {
   let isChild = false;
 
-  // It is only a child if it's immediate parent is a JSX element,
-  // or it is an ExpressionContainer who's parent is.
+  path.findParent((path) => {
+    if (path.isJSXAttribute()) {
+      // Stop traversing, we are not a child.
+      return true;
+    }
+    if (path.isJSXElement()) {
+      if (directChild(path)) {
+        return false;
+      }
+      // This element is the top of a tree of JSX elements
+      // If it's the root tree, we are a child.
+      isChild = isRootJSX(path);
+      return true;
+    }
+  });
+
+  return isChild;
+}
+
+// It is only a child if it's immediate parent is a JSX element,
+// or it is an ExpressionContainer who's parent is.
+function directChild(path) {
+  let isChild = false;
+
   path.findParent((path) => {
     if (path.isJSXElement()) {
       isChild = true;
       return true;
     }
-    return !path.isJSXExpressionContainer();
+    if (path.isJSXExpressionContainer()) {
+      // Defer to what the parent is.
+      return false;
+    }
+    return true;
   });
 
   return isChild;
+}
+
+// Detects if this element is not a child of another JSX element
+export default function isChildElement(path, { opts }) {
+  return directChild(path) || (opts.fastRoot && descendant(path));
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -44,8 +44,8 @@ export default function ({ types: t, traverse: _traverse }) {
 
     JSXElement: {
       enter(path) {
-        let { secondaryTree, root, closureVarsStack } = this;
-        const needsWrapper = secondaryTree || (root !== path && !isChildElement(path));
+        const { secondaryTree, root, closureVarsStack } = this;
+        const needsWrapper = secondaryTree || (root !== path && !isChildElement(path, this));
 
         // If this element needs to be wrapped in a closure, we need to transform
         // it's children without wrapping them.
@@ -61,9 +61,9 @@ export default function ({ types: t, traverse: _traverse }) {
       },
 
       exit(path) {
-        const { hoist } = this.opts;
         const { root, secondaryTree, replacedElements, closureVarsStack } = this;
-        const needsWrapper = secondaryTree || (root !== path && !isChildElement(path));
+        const { hoist } = this.opts;
+        const needsWrapper = secondaryTree || (root !== path && !isChildElement(path, this));
 
         const { parentPath } = path;
         const explicitReturn = parentPath.isReturnStatement();
@@ -171,7 +171,7 @@ export default function ({ types: t, traverse: _traverse }) {
 
       Function: {
         exit(path) {
-          const secondaryTree = !isChildElement(path);
+          const secondaryTree = !isChildElement(path, this);
           const state = Object.assign({}, this, {
             secondaryTree,
             root: path,

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import isRootJSX from "./helpers/is-root-jsx";
 import isReturned from "./helpers/is-returned";
-import isChildElement from "./helpers/is-child-element";
+import childAncestor from "./helpers/is-child-element";
 import { setupInjector, injectHelpers } from "./helpers/inject";
 import { setupHoists, hoist, addHoistedDeclarator } from "./helpers/hoist";
 
@@ -45,7 +45,7 @@ export default function ({ types: t, traverse: _traverse }) {
     JSXElement: {
       enter(path) {
         const { secondaryTree, root, closureVarsStack } = this;
-        const needsWrapper = secondaryTree || (root !== path && !isChildElement(path, this));
+        const needsWrapper = secondaryTree || (root !== path && !childAncestor(path, this));
 
         // If this element needs to be wrapped in a closure, we need to transform
         // it's children without wrapping them.
@@ -63,7 +63,8 @@ export default function ({ types: t, traverse: _traverse }) {
       exit(path) {
         const { root, secondaryTree, replacedElements, closureVarsStack } = this;
         const { hoist } = this.opts;
-        const needsWrapper = secondaryTree || (root !== path && !isChildElement(path, this));
+        const childAncestorPath = childAncestor(path, this);
+        const needsWrapper = secondaryTree || (root !== path && !childAncestorPath);
 
         const { parentPath } = path;
         const explicitReturn = parentPath.isReturnStatement();
@@ -119,6 +120,10 @@ export default function ({ types: t, traverse: _traverse }) {
           return;
         }
 
+        if (childAncestorPath) {
+          replacedElements.add(childAncestorPath.node);
+        }
+
         // This is the main JSX element. Replace the return statement
         // with all the nested calls, returning the main JSX element.
         if (explicitReturn) {
@@ -171,7 +176,7 @@ export default function ({ types: t, traverse: _traverse }) {
 
       Function: {
         exit(path) {
-          const secondaryTree = !isChildElement(path, this);
+          const secondaryTree = !childAncestor(path, this);
           const state = Object.assign({}, this, {
             secondaryTree,
             root: path,

--- a/test/fixtures/attributes/element-in-attribute/actual.js
+++ b/test/fixtures/attributes/element-in-attribute/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  return <ul files={files.map((file) => {
+    return <li key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</li>;
+  })}></ul>;
+}

--- a/test/fixtures/attributes/element-in-attribute/expected.js
+++ b/test/fixtures/attributes/element-in-attribute/expected.js
@@ -1,0 +1,44 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul", null, null, "files", files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li", _file$name, ["key", _file$name], "file", _file, "onclick", _ref);
+
+      _renderArbitrary(_file$name2);
+
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  }));
+  return elementClose("ul");
+}

--- a/test/fixtures/attributes/nested-element-in-attribute/actual.js
+++ b/test/fixtures/attributes/nested-element-in-attribute/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  return <ul files={files.map((file) => {
+    return <li>
+      <span key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</span>
+    </li>
+  })}></ul>;
+}

--- a/test/fixtures/attributes/nested-element-in-attribute/expected.js
+++ b/test/fixtures/attributes/nested-element-in-attribute/expected.js
@@ -1,0 +1,46 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul", null, null, "files", files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li");
+      elementOpen("span", _file$name, ["key", _file$name], "file", _file, "onclick", _ref);
+
+      _renderArbitrary(_file$name2);
+
+      elementClose("span");
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  }));
+  return elementClose("ul");
+}

--- a/test/fixtures/fast-root/attribute-nested-attribute/actual.js
+++ b/test/fixtures/fast-root/attribute-nested-attribute/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  return <ul files={files.map((file) => {
+    return <li attr={
+      <span key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</span>
+    }></li>
+  })}></ul>;
+}

--- a/test/fixtures/fast-root/attribute-nested-attribute/expected.js
+++ b/test/fixtures/fast-root/attribute-nested-attribute/expected.js
@@ -1,0 +1,47 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul", null, null, "files", files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li", null, null, "attr", _jsxWrapper(function (_file$name3, _file2, _ref2, _file$name4) {
+        elementOpen("span", _file$name3, ["key", _file$name3], "file", _file2, "onclick", _ref2);
+
+        _renderArbitrary(_file$name4);
+
+        return elementClose("span");
+      }, [_file$name, _file, _ref, _file$name2]));
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  }));
+  return elementClose("ul");
+}

--- a/test/fixtures/fast-root/attribute-nested-attribute/options.json
+++ b/test/fixtures/fast-root/attribute-nested-attribute/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/attribute/actual.js
+++ b/test/fixtures/fast-root/attribute/actual.js
@@ -1,0 +1,5 @@
+function render() {
+  return <ul files={files.map((file) => {
+    return <li key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</li>
+  })}></ul>;
+}

--- a/test/fixtures/fast-root/attribute/expected.js
+++ b/test/fixtures/fast-root/attribute/expected.js
@@ -1,0 +1,44 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul", null, null, "files", files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li", _file$name, ["key", _file$name], "file", _file, "onclick", _ref);
+
+      _renderArbitrary(_file$name2);
+
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  }));
+  return elementClose("ul");
+}

--- a/test/fixtures/fast-root/attribute/options.json
+++ b/test/fixtures/fast-root/attribute/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/element/actual.js
+++ b/test/fixtures/fast-root/element/actual.js
@@ -1,0 +1,9 @@
+function render() {
+  return <ul>
+  {
+    files.map((file) => {
+      return <li key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</li>
+    })
+  }
+  </ul>;
+}

--- a/test/fixtures/fast-root/element/expected.js
+++ b/test/fixtures/fast-root/element/expected.js
@@ -22,8 +22,7 @@ var _renderArbitrary = function _renderArbitrary(child) {
 
 function render() {
   elementOpen("ul");
-
-  _renderArbitrary(files.map(function (file) {
+  files.map(function (file) {
     elementOpen("li", file.name, ["key", file.name], "file", file, "onclick", function (e) {
       return fileClicked(e, file);
     });
@@ -31,7 +30,6 @@ function render() {
     _renderArbitrary(file.name);
 
     return elementClose("li");
-  }));
-
+  });
   return elementClose("ul");
 }

--- a/test/fixtures/fast-root/element/expected.js
+++ b/test/fixtures/fast-root/element/expected.js
@@ -1,0 +1,37 @@
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul");
+
+  _renderArbitrary(files.map(function (file) {
+    elementOpen("li", file.name, ["key", file.name], "file", file, "onclick", function (e) {
+      return fileClicked(e, file);
+    });
+
+    _renderArbitrary(file.name);
+
+    return elementClose("li");
+  }));
+
+  return elementClose("ul");
+}

--- a/test/fixtures/fast-root/element/options.json
+++ b/test/fixtures/fast-root/element/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/nested-attribute-nested-attribute/actual.js
+++ b/test/fixtures/fast-root/nested-attribute-nested-attribute/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  return <ul files={files.map((file) => {
+    return <li attr={
+      <span><span key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</span></span>
+    }></li>
+  })}></ul>;
+}

--- a/test/fixtures/fast-root/nested-attribute-nested-attribute/expected.js
+++ b/test/fixtures/fast-root/nested-attribute-nested-attribute/expected.js
@@ -1,0 +1,49 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul", null, null, "files", files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li", null, null, "attr", _jsxWrapper(function (_file$name3, _file2, _ref2, _file$name4) {
+        elementOpen("span");
+        elementOpen("span", _file$name3, ["key", _file$name3], "file", _file2, "onclick", _ref2);
+
+        _renderArbitrary(_file$name4);
+
+        elementClose("span");
+        return elementClose("span");
+      }, [_file$name, _file, _ref, _file$name2]));
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  }));
+  return elementClose("ul");
+}

--- a/test/fixtures/fast-root/nested-attribute-nested-attribute/options.json
+++ b/test/fixtures/fast-root/nested-attribute-nested-attribute/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/nested-attribute/actual.js
+++ b/test/fixtures/fast-root/nested-attribute/actual.js
@@ -1,0 +1,7 @@
+function render() {
+  return <ul files={files.map((file) => {
+    return <li>
+      <span key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</span>
+    </li>
+  })}></ul>;
+}

--- a/test/fixtures/fast-root/nested-attribute/expected.js
+++ b/test/fixtures/fast-root/nested-attribute/expected.js
@@ -1,0 +1,46 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("ul", null, null, "files", files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li");
+      elementOpen("span", _file$name, ["key", _file$name], "file", _file, "onclick", _ref);
+
+      _renderArbitrary(_file$name2);
+
+      elementClose("span");
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  }));
+  return elementClose("ul");
+}

--- a/test/fixtures/fast-root/nested-attribute/options.json
+++ b/test/fixtures/fast-root/nested-attribute/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/nested-child-element/actual.js
+++ b/test/fixtures/fast-root/nested-child-element/actual.js
@@ -1,0 +1,9 @@
+function render() {
+  return <root>
+  {
+    files.map((file) => {
+      return <li><span key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</span></li>
+    })
+  }
+  </root>;
+}

--- a/test/fixtures/fast-root/nested-child-element/expected.js
+++ b/test/fixtures/fast-root/nested-child-element/expected.js
@@ -22,16 +22,16 @@ var _renderArbitrary = function _renderArbitrary(child) {
 
 function render() {
   elementOpen("root");
-  elementOpen("ul");
   files.map(function (file) {
-    elementOpen("li", file.name, ["key", file.name], "file", file, "onclick", function (e) {
+    elementOpen("li");
+    elementOpen("span", file.name, ["key", file.name], "file", file, "onclick", function (e) {
       return fileClicked(e, file);
     });
 
     _renderArbitrary(file.name);
 
+    elementClose("span");
     return elementClose("li");
   });
-  elementClose("ul");
   return elementClose("root");
 }

--- a/test/fixtures/fast-root/nested-child-element/options.json
+++ b/test/fixtures/fast-root/nested-child-element/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/nested-element/actual.js
+++ b/test/fixtures/fast-root/nested-element/actual.js
@@ -1,0 +1,9 @@
+function render() {
+  return <root><ul>
+  {
+    files.map((file) => {
+      return <li key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</li>
+    })
+  }
+  </ul></root>;
+}

--- a/test/fixtures/fast-root/nested-element/expected.js
+++ b/test/fixtures/fast-root/nested-element/expected.js
@@ -1,0 +1,39 @@
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  elementOpen("root");
+  elementOpen("ul");
+
+  _renderArbitrary(files.map(function (file) {
+    elementOpen("li", file.name, ["key", file.name], "file", file, "onclick", function (e) {
+      return fileClicked(e, file);
+    });
+
+    _renderArbitrary(file.name);
+
+    return elementClose("li");
+  }));
+
+  elementClose("ul");
+  return elementClose("root");
+}

--- a/test/fixtures/fast-root/nested-element/options.json
+++ b/test/fixtures/fast-root/nested-element/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/nested-nested-child-element/actual.js
+++ b/test/fixtures/fast-root/nested-nested-child-element/actual.js
@@ -1,0 +1,9 @@
+function render() {
+  return <root><ul>
+  {
+    files.map((file) => {
+      return <li><span key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</span></li>
+    })
+  }
+  </ul></root>;
+}

--- a/test/fixtures/fast-root/nested-nested-child-element/expected.js
+++ b/test/fixtures/fast-root/nested-nested-child-element/expected.js
@@ -24,12 +24,14 @@ function render() {
   elementOpen("root");
   elementOpen("ul");
   files.map(function (file) {
-    elementOpen("li", file.name, ["key", file.name], "file", file, "onclick", function (e) {
+    elementOpen("li");
+    elementOpen("span", file.name, ["key", file.name], "file", file, "onclick", function (e) {
       return fileClicked(e, file);
     });
 
     _renderArbitrary(file.name);
 
+    elementClose("span");
     return elementClose("li");
   });
   elementClose("ul");

--- a/test/fixtures/fast-root/nested-nested-child-element/options.json
+++ b/test/fixtures/fast-root/nested-nested-child-element/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/fixtures/fast-root/secondary-element/actual.js
+++ b/test/fixtures/fast-root/secondary-element/actual.js
@@ -1,0 +1,10 @@
+function render() {
+  var ul = <ul>
+  {
+    files.map((file) => {
+      return <li key={file.name} file={file} onclick={(e) => fileClicked(e, file)}>{file.name}</li>
+    })
+  }
+  </ul>;
+  return <root>{ul}</root>;
+}

--- a/test/fixtures/fast-root/secondary-element/expected.js
+++ b/test/fixtures/fast-root/secondary-element/expected.js
@@ -1,0 +1,54 @@
+var _jsxWrapper = function _jsxWrapper(func, args) {
+  var wrapper = args ? function wrapper() {
+    return func.apply(this, args);
+  } : func;
+  wrapper.__jsxDOMWrapper = true;
+  return wrapper;
+};
+
+var _hasOwn = Object.prototype.hasOwnProperty;
+
+var _forOwn = function _forOwn(object, iterator) {
+  for (var prop in object) {
+    if (_hasOwn.call(object, prop)) iterator(object[prop], prop);
+  }
+};
+
+var _renderArbitrary = function _renderArbitrary(child) {
+  var type = typeof child;
+
+  if (type === "number" || type === "string" || child && child instanceof String) {
+    text(child);
+  } else if (type === "function" && child.__jsxDOMWrapper) {
+    child();
+  } else if (Array.isArray(child)) {
+    child.forEach(_renderArbitrary);
+  } else if (String(child) === "[object Object]") {
+    _forOwn(child, _renderArbitrary);
+  }
+};
+
+function render() {
+  var ul = _jsxWrapper(function (_files$map) {
+    elementOpen("ul");
+
+    _renderArbitrary(_files$map);
+
+    return elementClose("ul");
+  }, [files.map(function (file) {
+    return _jsxWrapper(function (_file$name, _file, _ref, _file$name2) {
+      elementOpen("li", _file$name, ["key", _file$name], "file", _file, "onclick", _ref);
+
+      _renderArbitrary(_file$name2);
+
+      return elementClose("li");
+    }, [file.name, file, function (e) {
+      return fileClicked(e, file);
+    }, file.name]);
+  })]);
+  elementOpen("root");
+
+  _renderArbitrary(ul);
+
+  return elementClose("root");
+}

--- a/test/fixtures/fast-root/secondary-element/options.json
+++ b/test/fixtures/fast-root/secondary-element/options.json
@@ -1,0 +1,5 @@
+{
+  "options": {
+    "fastRoot": true
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -88,4 +88,4 @@ function findTests(root) {
   }
 }
 
-findTests(path.join(__dirname, "fixtures", "fast-root"));
+findTests(path.join(__dirname, "fixtures"));

--- a/test/index.js
+++ b/test/index.js
@@ -88,4 +88,4 @@ function findTests(root) {
   }
 }
 
-findTests(path.join(__dirname, "fixtures"));
+findTests(path.join(__dirname, "fixtures", "fast-root"));


### PR DESCRIPTION
Treat JSX Elements inside the root as "fast". This breaks from traditional JSX (and you can shoot yourself in the foot), but it will speed up a few very common patterns like array mapping.

Closes #40.