### PR TITLE
Create a spreadAttribute runtime function

### DIFF
--- a/src/helpers/attributes.js
+++ b/src/helpers/attributes.js
@@ -1,5 +1,4 @@
-import injectAttr from "./runtime/attr";
-import injectForOwn from "./runtime/for-own";
+import injectSpreadAttribute from "./runtime/spread-attribute";
 import toFunctionCall from "./ast/to-function-call";
 import iDOMMethod from "./idom-method";
 
@@ -21,15 +20,14 @@ export function toAttrsArray(attrs) {
 
 // Returns an array of iDOM `attr` calls
 export function toAttrsCalls(attrs, plugin) {
-  const attrCall = iDOMMethod("attr", plugin);
-  const forOwn = injectForOwn(plugin);
-  const forOwnAttr = injectAttr(plugin);
+  const attr = iDOMMethod("attr", plugin);
+  const spreadAttr = injectSpreadAttribute(plugin);
 
   return attrs.map(({ name, value, isSpread }) => {
     if (isSpread) {
-      return toFunctionCall(forOwn, [ value, forOwnAttr ]);
+      return toFunctionCall(spreadAttr, [value]);
     }
 
-    return toFunctionCall(attrCall, [ name, value ]);
+    return toFunctionCall(attr, [ name, value ]);
   });
 }

--- a/src/helpers/runtime/attr.js
+++ b/src/helpers/runtime/attr.js
@@ -6,12 +6,12 @@ import * as t from "babel-types";
 // Flip flops the arguments when calling iDOM's
 // `attr`, so that this function may be used
 // as an iterator like an Object#forEach.
-function attrAST(plugin, ref) {
+function flipAttrAST(plugin, ref) {
   const name = t.identifier("name");
   const value = t.identifier("value");
 
   /**
-   * function _attr(value, prop) {
+   * function _flipAttr(value, prop) {
    *   attr(prop, value);
    * }
    */
@@ -24,6 +24,6 @@ function attrAST(plugin, ref) {
   );
 }
 
-export default function injectAttr(plugin) {
-  return inject(plugin, "attr", attrAST);
+export default function injectFlipAttr(plugin) {
+  return inject(plugin, "flipAttr", flipAttrAST);
 }

--- a/src/helpers/runtime/spread-attribute.js
+++ b/src/helpers/runtime/spread-attribute.js
@@ -1,0 +1,32 @@
+import inject from "../inject";
+import injectForOwn from "./for-own";
+import injectFlipAttr from "./attr";
+import toFunctionCall from "../ast/to-function-call";
+import * as t from "babel-types";
+
+// Iterates over a SpreadAttribute, assigning each property as an attribute
+// on the element.
+function spreadAttributeAST(plugin, ref, deps) {
+  const { forOwn, attr } = deps;
+  const spread = t.identifier("spread");
+
+  /**
+   * function _spreadAttribute(spread) {
+   *   _forOwn(spread, _attr);
+   * }
+   */
+  return t.functionExpression(
+    ref,
+    [spread],
+    t.blockStatement([
+      t.expressionStatement(toFunctionCall(forOwn, [spread, attr]))
+    ])
+  );
+}
+
+export default function injectSpreadAttribute(plugin) {
+  return inject(plugin, "spreadAttribute", spreadAttributeAST, {
+    forOwn: injectForOwn,
+    attr: injectFlipAttr
+  });
+}

--- a/test/fixtures/prefix/all-together-now/expected.js
+++ b/test/fixtures/prefix/all-together-now/expected.js
@@ -12,7 +12,7 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   IncrementalDOM.attr(name, value);
 };
 
@@ -24,17 +24,21 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   IncrementalDOM.elementOpen("div");
   IncrementalDOM.elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   IncrementalDOM.elementOpenEnd("div");
   IncrementalDOM.elementClose("div");
   IncrementalDOM.elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   IncrementalDOM.elementOpenEnd("div");
   IncrementalDOM.elementClose("div");

--- a/test/fixtures/prefix/deep-prefix/expected.js
+++ b/test/fixtures/prefix/deep-prefix/expected.js
@@ -12,7 +12,7 @@ var _renderArbitrary = function _renderArbitrary(child) {
   }
 };
 
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   IncrementalDOM.virtual.elements.attr(name, value);
 };
 
@@ -24,17 +24,21 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   IncrementalDOM.virtual.elements.elementOpen("div");
   IncrementalDOM.virtual.elements.elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   IncrementalDOM.virtual.elements.elementOpenEnd("div");
   IncrementalDOM.virtual.elements.elementClose("div");
   IncrementalDOM.virtual.elements.elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   IncrementalDOM.virtual.elements.elementOpenEnd("div");
   IncrementalDOM.virtual.elements.elementClose("div");

--- a/test/fixtures/prefix/nested-spread-attributes/expected.js
+++ b/test/fixtures/prefix/nested-spread-attributes/expected.js
@@ -1,4 +1,4 @@
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   IncrementalDOM.attr(name, value);
 };
 
@@ -10,11 +10,15 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   IncrementalDOM.elementOpen("div");
   IncrementalDOM.elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   IncrementalDOM.elementOpenEnd("div");
   IncrementalDOM.elementClose("div");

--- a/test/fixtures/prefix/nested-spread/expected.js
+++ b/test/fixtures/prefix/nested-spread/expected.js
@@ -1,4 +1,4 @@
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   IncrementalDOM.attr(name, value);
 };
 
@@ -10,11 +10,15 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   IncrementalDOM.elementOpen("div");
   IncrementalDOM.elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   IncrementalDOM.elementOpenEnd("div");
   IncrementalDOM.elementClose("div");

--- a/test/fixtures/runtime/module/spread/expected.js
+++ b/test/fixtures/runtime/module/spread/expected.js
@@ -2,7 +2,7 @@ var _iDOM = require("iDOM");
 
 function render() {
   elementOpenStart("div");
-  (0, _iDOM.forOwn)(props, _iDOM.attr);
+  (0, _iDOM.spreadAttribute)(props);
   elementOpenEnd("div");
   return elementClose("div");
 }

--- a/test/fixtures/runtime/prefix/spread/expected.js
+++ b/test/fixtures/runtime/prefix/spread/expected.js
@@ -1,6 +1,6 @@
 function render() {
   elementOpenStart("div");
-  iDOM.forOwn(props, iDOM.attr);
+  iDOM.spreadAttribute(props);
   elementOpenEnd("div");
   return elementClose("div");
 }

--- a/test/fixtures/spread-attributes/combined-attributes/expected.js
+++ b/test/fixtures/spread-attributes/combined-attributes/expected.js
@@ -1,4 +1,4 @@
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   attr(name, value);
 };
 
@@ -10,15 +10,19 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   elementOpenStart("div", "test", ["class", "test", "key", "test"]);
   attr("id", id);
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   attr("data-expanded", expanded);
 
-  _forOwn(props.attrs, _attr);
+  _spreadAttribute(props.attrs);
 
   elementOpenEnd("div");
   return elementClose("div");

--- a/test/fixtures/spread-attributes/self-closing/expected.js
+++ b/test/fixtures/spread-attributes/self-closing/expected.js
@@ -1,4 +1,4 @@
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   attr(name, value);
 };
 
@@ -10,10 +10,14 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   elementOpenStart("div");
 
-  _forOwn(props, _attr);
+  _spreadAttribute(props);
 
   elementOpenEnd("div");
   return elementClose("div");

--- a/test/fixtures/spread-attributes/variable/expected.js
+++ b/test/fixtures/spread-attributes/variable/expected.js
@@ -6,7 +6,7 @@ var _jsxWrapper = function _jsxWrapper(func, args) {
   return wrapper;
 };
 
-var _attr = function _attr(value, name) {
+var _flipAttr = function _flipAttr(value, name) {
   attr(name, value);
 };
 
@@ -18,11 +18,15 @@ var _forOwn = function _forOwn(object, iterator) {
   }
 };
 
+var _spreadAttribute = function _spreadAttribute(spread) {
+  _forOwn(spread, _flipAttr);
+};
+
 function render() {
   var test = _jsxWrapper(function (_props) {
     elementOpenStart("div");
 
-    _forOwn(_props, _attr);
+    _spreadAttribute(_props);
 
     elementOpenEnd("div");
     return elementClose("div");


### PR DESCRIPTION
This reduced the number of required runtime functions from 5 to 3,
removing the two “sub helpers” `attr` and `forOwn`. It’s not really up
to me how you write those functions, and using `spreadAttribute`
exposes the core need instead of depending on the two.

**This is a breaking change**.
